### PR TITLE
Changed ecdsa_curve to rsa_bits

### DIFF
--- a/aws/compute.tf
+++ b/aws/compute.tf
@@ -21,8 +21,8 @@ locals {
 }
 
 resource "tls_private_key" "provisioner_key" {
-  algorithm   = "RSA"  # AWS only supports RSE, not ECDSA
-  ecdsa_curve = "4096"
+  algorithm   = "RSA"  # AWS only supports RSA, not ECDSA
+  rsa_bits = "4096"
 }
 
 resource "aws_instance" "mgmt" {


### PR DESCRIPTION
An error occurred when validating the AWS terraform file: "Expected ecdsa_curve to be one of [P224 P256 P384 P521]". As the comment states, AWS only supports RSA; the command was changed from expecting an ecdsa_curve to rsa_bits, which subsequently removes the error and allows validation to succeed.